### PR TITLE
Migrate minimum Python version from 3.9 to 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,11 +11,11 @@ jobs:
     name: Generate Icons
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: "3.10"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -36,10 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: "3.9"
+        python-version: "3.10"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "roentgen-icons"
 version = "0.10.0"
 description = "Set of monochrome 14 × 14 px pixel-aligned map icons"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [{ name = "Sergey Vartanov", email = "me@enzet.ru" }]
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Fixes #8

## Summary
Python 3.9 reached end-of-life on October 2, 2025. This PR migrates the project to Python 3.10 as the minimum supported version.

## Changes

**pyproject.toml**
- Updated `requires-python` from `>=3.9` to `>=3.10`

**`.github/workflows/test.yml`**
- Updated Python version from 3.9 to 3.10 in both CI jobs
- Fixed unquoted `python-version: 3.9` → `python-version: "3.10"` (unquoted 3.10 is interpreted as 3.1 in YAML)
- Bumped `actions/checkout` from v2 to v4
- Bumped `actions/setup-python` from v2 to v5

## Testing
- CI will validate the build and tests pass on Python 3.10+